### PR TITLE
Line 27: add .strip() to directory string

### DIFF
--- a/3_save.py
+++ b/3_save.py
@@ -24,7 +24,7 @@ def save(online=True):
 		for i in range(4):
 			dirs.append(video[i].strip()[0:MAX_NAME_LENGTH])
 
-		directory = "{}/{}/{}".format(base_folder,dirs[0],dirs[2])
+		directory = "{}/{}/{}".format(base_folder,dirs[0],dirs[2]).strip()
 		path = "{}/{}.{}".format(directory,dirs[3],extension)
 		srt_path = "{}/{}.srt".format(directory,dirs[3])
 


### PR DESCRIPTION
If the program truncates the user's Keats module leaving a leading space (e.g., library/module /video.mp4), it creates a directory without space (library/module/video.mp4), then in line 42 tries to access the directory with space then errors out.